### PR TITLE
Merge to patch-4(Proposals.Slice) of the fork from original repo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NestedSamplers"
 uuid = "41ceaf6f-1696-4a54-9b49-2e7a9ec3782e"
 authors = ["Miles Lucas <mdlucas@hawaii.edu>"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NestedSamplers"
 uuid = "41ceaf6f-1696-4a54-9b49-2e7a9ec3782e"
 authors = ["Miles Lucas <mdlucas@hawaii.edu>"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ chain = sample(model, spl;
 
 
 ````
-Object of type Chains, with data of type 359×3×1 Array{Float64,3}
+Object of type Chains, with data of type 362×3×1 Array{Float64,3}
 
-Log evidence      = 2.0768046287159097
-Iterations        = 1:359
+Log evidence      = 2.058546305361165
+Iterations        = 1:362
 Thinning interval = 1
 Chains            = 1
-Samples per chain = 359
+Samples per chain = 362
 internals         = weights
 parameters        = x, y
 
@@ -84,14 +84,14 @@ parameters        = x, y
 Summary Statistics
   parameters    mean     std  naive_se    mcse       ess   r_hat
   ──────────  ──────  ──────  ────────  ──────  ────────  ──────
-           x  0.5038  0.3034    0.0160  0.0303  322.1553  1.0011
-           y  0.4903  0.2971    0.0157  0.0139  251.3237  0.9976
+           x  0.5041  0.2963    0.0156  0.0120  403.7804  1.0010
+           y  0.4996  0.2929    0.0154  0.0289  366.7010  0.9981
 
 Quantiles
   parameters    2.5%   25.0%   50.0%   75.0%   97.5%
   ──────────  ──────  ──────  ──────  ──────  ──────
-           x  0.0319  0.2054  0.5202  0.7827  0.9713
-           y  0.0352  0.1974  0.5018  0.7867  0.9397
+           x  0.0309  0.2203  0.4961  0.7975  0.9539
+           y  0.0583  0.2110  0.4911  0.7982  0.9677
 ````
 
 

--- a/src/bounds/Bounds.jl
+++ b/src/bounds/Bounds.jl
@@ -40,6 +40,7 @@ The following functionality defines the interface for `AbstractBoundingSpace` fo
 | `Bounds.volume(::MyBounds)` | | Retrieve the current prior volume occupied by the bounds. |
 | `Bounds.fit(::Type{<:MyBounds}, points, pointvol=0)` | x | update the bounds given the new `points` each with minimum volume `pointvol`|
 | `Bounds.axes(::MyBounds)` | | Used for transforming points from the unit cube to the encompassing bound.
+| `Bounds.tran_axes(::MyBounds)` | | Used for Gibbs-like multivariate slice sampling (`Proposals.Slice`)
 """
 abstract type AbstractBoundingSpace{T <: Number} end
 
@@ -94,7 +95,8 @@ fit(::Type{<:NoBounds}, points::AbstractMatrix{T}; kwargs...) where T =
     NoBounds(T, size(points, 1))
 scale!(b::NoBounds, factor) = b
 volume(::NoBounds{T}) where {T} = one(T)
-axes(b::NoBounds) = I
+axes(b::NoBounds) = I(b.ndims)
+tran_axes(b::NoBounds) = I(b.ndims)
 
 
 include("ellipsoid.jl")

--- a/src/bounds/Bounds.jl
+++ b/src/bounds/Bounds.jl
@@ -95,8 +95,8 @@ fit(::Type{<:NoBounds}, points::AbstractMatrix{T}; kwargs...) where T =
     NoBounds(T, size(points, 1))
 scale!(b::NoBounds, factor) = b
 volume(::NoBounds{T}) where {T} = one(T)
-axes(b::NoBounds) = I(b.ndims)
-tran_axes(b::NoBounds) = I(b.ndims)
+axes(b::NoBounds) = I
+tran_axes(b::NoBounds) = I
 
 
 include("ellipsoid.jl")

--- a/src/bounds/ellipsoid.jl
+++ b/src/bounds/ellipsoid.jl
@@ -38,6 +38,8 @@ volume(ell::Ellipsoid) = ell.volume
 # Returns the principal axes
 axes(ell::Ellipsoid) = ell.axes
 
+tran_axes(ell::Ellipsoid) = inv(cholesky(ell.A).L)
+
 function decompose(A::AbstractMatrix)
     E = eigen(A)
     axlens = @. 1 / sqrt(E.values)

--- a/test/bounds/bounds.jl
+++ b/test/bounds/bounds.jl
@@ -84,18 +84,7 @@ end
 
     @test eltype(samples) == T
     @test size(samples) == (D, 3)
-    p = all(samples[:, i] ∈ bound for i in axes(samples, 2))
-    if !p
-        @info "ERROR DETECTED, CALCULATING MISGRIEVANCES"
-        for i in axes(samples, 2)
-            if samples[:, i] ∉ bound
-                @info "    unbound point at idx $i"
-                @info "    point: $(samples[:, i])"
-            end
-        end
-        
-    end
-    @test p
+    @test all(samples[:, i] ∈ bound for i in axes(samples, 2))
 
     # fitting
     samples = randn(rng, T, D, 100)
@@ -113,6 +102,7 @@ end
     @test bound_scaled == bound
     @test Bounds.volume(bound_scaled) == 1
 
+    @test Bounds.axes(bound) == Bounds.tran_axes(bound) == I
 end
 
 include("helpers.jl")

--- a/test/bounds/ellipsoids.jl
+++ b/test/bounds/ellipsoids.jl
@@ -6,12 +6,14 @@ const NMAX = 20
     @testset "Spheres" begin 
         scale = 5
         center = 2scale .* ones(N)
-        A = diagm(0 => ones(N) ./ scale^2)
+        A = Matrix(I, N, N) ./ scale^2
         ell = Ellipsoid(center, A)
         @test volume(ell) ≈ volume_prefactor(N) * scale^N
         axs, axlens = decompose(ell)
         @test axlens ≈ fill(scale, N)
-        @test axs ≈ Bounds.axes(ell) ≈ diagm(0 => fill(scale, N))
+        @test axs ≈ Bounds.axes(ell) ≈ scale * I(N)
+        T = Bounds.tran_axes(ell)
+        @test inv(T * T') ≈ ell.A
     end
 
     @testset "Scaling" begin

--- a/test/bounds/ellipsoids.jl
+++ b/test/bounds/ellipsoids.jl
@@ -11,7 +11,7 @@ const NMAX = 20
         @test volume(ell) ≈ volume_prefactor(N) * scale^N
         axs, axlens = decompose(ell)
         @test axlens ≈ fill(scale, N)
-        @test axs ≈ Bounds.axes(ell) ≈ scale * I(N)
+        @test axs ≈ Bounds.axes(ell) ≈ scale * Matrix(I, N, N)
         T = Bounds.tran_axes(ell)
         @test inv(T * T') ≈ ell.A
     end


### PR DESCRIPTION
Merge changes to patch-4 (`Proposals.Slice`) of the fork from the original repository.
Changes include:
1. add `tran_axes` (for `Proposals.Slice`)
2. Update `Bounds.jl` and `ellipsoids.jl` to accomodate for `trans_axes`
3. bump version to 0.4 (earlier change)